### PR TITLE
Added WeakConcurrentMap and DetachedThreadLocal getIfPresent()

### DIFF
--- a/src/main/java/com/blogspot/mydailyjava/weaklockfree/DetachedThreadLocal.java
+++ b/src/main/java/com/blogspot/mydailyjava/weaklockfree/DetachedThreadLocal.java
@@ -39,6 +39,10 @@ public class DetachedThreadLocal<T> implements Runnable {
         return map.get(Thread.currentThread());
     }
 
+    public T getIfPresent() {
+      return map.getIfPresent(Thread.currentThread());
+    }
+
     public void set(T value) {
         map.put(Thread.currentThread(), value);
     }

--- a/src/main/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMap.java
+++ b/src/main/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMap.java
@@ -63,6 +63,15 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Runnab
 
     /**
      * @param key The key of the entry.
+     * @return The value of the entry or null if it did not exist.
+     */
+    public V getIfPresent(K key) {
+        if (key == null) throw new NullPointerException();
+        return target.get(new LatentKey<K>(key));
+    }
+
+    /**
+     * @param key The key of the entry.
      * @return {@code true} if the key already defines a value.
      */
     public boolean containsKey(K key) {

--- a/src/test/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMapTest.java
+++ b/src/test/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMapTest.java
@@ -79,11 +79,13 @@ public class WeakConcurrentMapTest {
             Thread.sleep(200L);
             triggerClean();
             assertThat(map.get(key3), is(value3));
+            assertThat(map.getIfPresent(key3), is(value3));
             assertThat(map.get(key4), is(value4));
             assertThat(map.approximateSize(), is(2));
             assertThat(map.target.size(), is(2));
             assertThat(map.remove(key3), is(value3));
             assertThat(map.get(key3), nullValue());
+            assertThat(map.getIfPresent(key3), nullValue());
             assertThat(map.get(key4), is(value4));
             assertThat(map.approximateSize(), is(1));
             assertThat(map.target.size(), is(1));


### PR DESCRIPTION
This allows to perform a get on WeakConcurrentMap that does not add a default value if if the supplier function would make one. The main purpose to support DetachedThreadLocal.getIfPresent() which does not initialize the ThreadLocalValue (use case is to "clear" the contents of a Thread local value. no need to create it if it should be just cleared)