### PR TITLE
Allows strategy used in Brave to avoid allocating on lookup

### DIFF
--- a/src/main/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMap.java
+++ b/src/main/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMap.java
@@ -97,11 +97,11 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Runnab
     public V get(K key) {
         if (key == null) throw new NullPointerException();
         V value;
-        LatentKey<K> latentKey = getKey(key);
+        Object lookupKey = getLookupKey(key);
         try {
-            value = target.get(latentKey);
+            value = target.get(lookupKey);
         } finally {
-            latentKey.reset();
+            resetLookupKey(lookupKey);
         }
         if (value == null) {
             value = defaultValue(key);
@@ -115,8 +115,15 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Runnab
         return value;
     }
 
+    /**
+     * Override with care as it can cause lookup failures if done incorrectly. The result must have
+     * the same {@link Object#hashCode()} as the input and be {@link Object#equals(Object) equal to}
+     * a weak reference of the key. When overriding this, also override {@link #resetLookupKey}.
+     *
+     * <p>By default, this wraps in a {@link LatentKey} possibly sourced from a thread-local.
+     */
     @SuppressWarnings("unchecked")
-    private LatentKey<K> getKey(K key) {
+    protected Object getLookupKey(K key) {
         LatentKey<K> latentKey;
         if (reuseKeys) {
             latentKey = (LatentKey<K>) LATENT_KEY_CACHE.get();
@@ -127,16 +134,26 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Runnab
     }
 
     /**
+     * Resets any reusable state in the {@linkplain #getLookupKey lookup key}. By default, this
+     * calls {@link LatentKey#reset()}.
+     */
+    protected void resetLookupKey(Object lookupKey) {
+        if (lookupKey instanceof WeakConcurrentMap.LatentKey) {
+            ((LatentKey) lookupKey).reset();
+        }
+    }
+
+    /**
      * @param key The key of the entry.
      * @return The value of the entry or null if it did not exist.
      */
     public V getIfPresent(K key) {
         if (key == null) throw new NullPointerException();
-        LatentKey<K> latentKey = getKey(key);
+        Object lookupKey = getLookupKey(key);
         try {
-            return target.get(latentKey);
+            return target.get(lookupKey);
         } finally {
-            latentKey.reset();
+            resetLookupKey(lookupKey);
         }
     }
 
@@ -146,11 +163,11 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Runnab
      */
     public boolean containsKey(K key) {
         if (key == null) throw new NullPointerException();
-        LatentKey<K> latentKey = getKey(key);
+        Object lookupKey = getLookupKey(key);
         try {
-            return target.containsKey(latentKey);
+            return target.containsKey(lookupKey);
         } finally {
-            latentKey.reset();
+            resetLookupKey(lookupKey);
         }
     }
 
@@ -172,11 +189,11 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Runnab
     public V putIfAbsent(K key, V value) {
         if (key == null || value == null) throw new NullPointerException();
         V previous;
-        LatentKey<K> latentKey = getKey(key);
+        Object lookupKey = getLookupKey(key);
         try {
-            previous = target.get(latentKey);
+            previous = target.get(lookupKey);
         } finally {
-            latentKey.reset();
+            resetLookupKey(lookupKey);
         }
         return previous == null ? target.putIfAbsent(new WeakKey<K>(key, this), value) : previous;
     }
@@ -197,11 +214,11 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Runnab
      */
     public V remove(K key) {
         if (key == null) throw new NullPointerException();
-        LatentKey<K> latentKey = getKey(key);
+        Object lookupKey = getLookupKey(key);
         try {
-            return target.remove(latentKey);
+            return target.remove(lookupKey);
         } finally {
-            latentKey.reset();
+            resetLookupKey(lookupKey);
         }
     }
 

--- a/src/test/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMapTest.java
+++ b/src/test/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMapTest.java
@@ -46,7 +46,10 @@ public class WeakConcurrentMapTest {
 
     static class KeyEqualToWeakRefOfItself {
         @Override public boolean equals(Object obj) {
-            return super.equals(obj instanceof WeakReference ? ((WeakReference)obj).get(): obj);
+            if (obj instanceof WeakReference) {
+                return equals(((WeakReference) obj).get());
+            }
+            return super.equals(obj);
         }
     }
 

--- a/src/test/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMapTest.java
+++ b/src/test/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMapTest.java
@@ -1,5 +1,6 @@
 package com.blogspot.mydailyjava.weaklockfree;
 
+import java.lang.ref.WeakReference;
 import org.junit.Test;
 
 import java.util.*;
@@ -41,6 +42,41 @@ public class WeakConcurrentMapTest {
         map.getCleanerThread().interrupt();
         Thread.sleep(200L);
         assertThat(map.getCleanerThread().isAlive(), is(false));
+    }
+
+    static class KeyEqualToWeakRefOfItself {
+        @Override public boolean equals(Object obj) {
+            return super.equals(obj instanceof WeakReference ? ((WeakReference)obj).get(): obj);
+        }
+    }
+
+    static class CheapUnloadableWeakConcurrentMap
+        extends WeakConcurrentMap<KeyEqualToWeakRefOfItself, Object> {
+
+        CheapUnloadableWeakConcurrentMap() {
+            super(false);
+        }
+
+        @Override protected Object getLookupKey(KeyEqualToWeakRefOfItself key) {
+            return key;
+        }
+
+        @Override protected void resetLookupKey(Object lookupKey) {
+        }
+    }
+
+    @Test
+    public void testKeyWithWeakRefEquals() {
+        CheapUnloadableWeakConcurrentMap map = new CheapUnloadableWeakConcurrentMap();
+
+        KeyEqualToWeakRefOfItself key = new KeyEqualToWeakRefOfItself();
+        Object value = new Object();
+        map.put(key, value);
+        assertThat(map.containsKey(key), is(true));
+        assertThat(map.get(key), is(value));
+        assertThat(map.putIfAbsent(key, new Object()), is(value));
+        assertThat(map.remove(key), is(value));
+        assertThat(map.containsKey(key), is(false));
     }
 
     private class MapTestCase {


### PR DESCRIPTION
The Brave tracing library has a modified version of this type, which we
use for tracking in-flight (pending) spans.

https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/internal/recorder/PendingSpans.java

I forgot to raise the feature back until now, which completely dodges
classloader issues and the need to use thread locals. If your map key
overrides `equals` in a way that it allows equality with a weak ref of
itself, you don't need any ceremony for lookup-based operations. This
can be a perfectly valid tradeoff for internal code, especially vs
holding up a classloader.