### PR TITLE
Expose a method to remove a stale reference for subclasses that overr…

### DIFF
--- a/src/main/java/com/blogspot/mydailyjava/weaklockfree/AbstractWeakConcurrentMap.java
+++ b/src/main/java/com/blogspot/mydailyjava/weaklockfree/AbstractWeakConcurrentMap.java
@@ -171,9 +171,8 @@ public abstract class AbstractWeakConcurrentMap<K, V, L> extends ReferenceQueue<
      * should generally only be used if overriding {@link #expungeStaleEntries()} to execute code
      * when references have been collected.
      *
-     * <pre>{@code
-     *
-     * class MyReferenceListener<K, V> extends WeakConcurrentMap.WithInlinedExpunction<K, V> {     *
+     * <pre>{@code     *
+     * class MyReferenceListener<K, V> extends WeakConcurrentMap.WithInlinedExpunction<K, V> {
      *   public void expungeStaleEntries() {
      *     Reference<?> reference;
      *     while ((reference = poll()) != null) {

--- a/src/main/java/com/blogspot/mydailyjava/weaklockfree/AbstractWeakConcurrentMap.java
+++ b/src/main/java/com/blogspot/mydailyjava/weaklockfree/AbstractWeakConcurrentMap.java
@@ -171,7 +171,7 @@ public abstract class AbstractWeakConcurrentMap<K, V, L> extends ReferenceQueue<
      * should generally only be used if overriding {@link #expungeStaleEntries()} to execute code
      * when references have been collected.
      *
-     * <pre>{@code     *
+     * <pre>{@code
      * class MyReferenceListener<K, V> extends WeakConcurrentMap.WithInlinedExpunction<K, V> {
      *   public void expungeStaleEntries() {
      *     Reference<?> reference;


### PR DESCRIPTION
…ide expungeStaleEntries.

As far as I can tell, there isn't a proper way of a subclass extending and overriding `expungeStaleEntries` since there's no way to actually remove the reference from the map, so it's a guaranteed memory leak. This exposes the removal for subclasses.

/cc @adriancole 