### PR TITLE
Add GitHub workflow build

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -1,0 +1,27 @@
+name: Continuous Build
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Maven
+        run: mvn -B package


### PR DESCRIPTION
I noticed in #12 that Travis didn't run despite there being a travis.yml in this repo. I'm just guessing that perhaps Travis credits have run out as this is affecting many repos lately. CI is a personal preference, so there is no need to accept this PR if you'd prefer not to. But thought I'd send it in case it can help.

https://github.com/anuraaga/weak-lock-free/runs/1446383316?check_suite_focus=true