### PR TITLE
Allow for easier WeakConcurrentMap subclassing

### DIFF
--- a/src/main/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMap.java
+++ b/src/main/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMap.java
@@ -52,7 +52,7 @@ public class WeakConcurrentMap<K, V> extends AbstractWeakConcurrentMap<K, V, Wea
      * @param classLoader The class loader to check.
      * @return {@code true} if the provided class loader can be unloaded.
      */
-    private static boolean isPersistentClassLoader(ClassLoader classLoader) {
+    protected static boolean isPersistentClassLoader(ClassLoader classLoader) {
         try {
             return classLoader == null // bootstrap class loader
                     || classLoader == ClassLoader.getSystemClassLoader()


### PR DESCRIPTION
The `isPersistentClassLoader` method is currently `private`, thus we can't reuse it when creating subclasses of `WeakConcurrentMap`.

This is definitely a very minor annoyance and was found when trying to provide a custom map through constructor, which is convenient when testing to be able to check when items are actually removed from the concurrent map.
Context : https://github.com/elastic/apm-agent-java/blob/012af603ce314abff0e04183cfaf61b537cf5495/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/weakmap/NullSafeWeakConcurrentMap.java#L47